### PR TITLE
[SWS-35] 장바구니 조회 API 생성

### DIFF
--- a/src/main/java/com/ite/sws/domain/cart/controller/CartController.java
+++ b/src/main/java/com/ite/sws/domain/cart/controller/CartController.java
@@ -1,0 +1,36 @@
+package com.ite.sws.domain.cart.controller;
+
+import com.ite.sws.domain.cart.dto.GetCartRes;
+import com.ite.sws.domain.cart.service.CartService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 장바구니 컨트롤러
+ * @author 김민정
+ * @since 2024.08.26
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자       수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.26  	김민정       최초 생성
+ * 2024.08.26  	김민정       장바구니 조회 API 생성
+ * </pre>
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/carts")
+public class CartController {
+
+    private final CartService cartService;
+
+    @GetMapping
+    public ResponseEntity<GetCartRes> cartItemList(@RequestParam Long memberId) {
+        return ResponseEntity.ok(cartService.findCartItemListByMemberId(memberId));
+    }
+}

--- a/src/main/java/com/ite/sws/domain/cart/dto/GetCartRes.java
+++ b/src/main/java/com/ite/sws/domain/cart/dto/GetCartRes.java
@@ -1,0 +1,32 @@
+package com.ite.sws.domain.cart.dto;
+
+import com.ite.sws.domain.cart.vo.CartItemVO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 장바구니 조회 Response DTO
+ * @author 김민정
+ * @since 2024.08.26
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자       수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.26  	김민정       최초 생성
+ * </pre>
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class GetCartRes {
+    private Long cartId;
+    private LocalDateTime createdAt;
+    private List<CartItemVO> items;
+}

--- a/src/main/java/com/ite/sws/domain/cart/mapper/CartMapper.java
+++ b/src/main/java/com/ite/sws/domain/cart/mapper/CartMapper.java
@@ -1,0 +1,45 @@
+package com.ite.sws.domain.cart.mapper;
+
+import com.ite.sws.domain.cart.vo.CartItemVO;
+import com.ite.sws.domain.cart.vo.CartVO;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+/**
+ * 장바구니 매퍼 인터페이스
+ * @author 김민정
+ * @since 2024.08.26
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자       수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.26  	김민정       최초 생성
+ * 2024.08.26  	김민정       ACTIVE 상태인 가장 최신의 Cart ID를 가져오기 기능 추가
+ * 2024.08.26  	김민정       Cart ID에 해당하는 장바구니 아이템 가져오기 기능 추가
+ * 2024.08.26  	김민정       새로운 장바구니 생성
+ * </pre>
+ */
+public interface CartMapper {
+
+    /**
+     * ACTIVE 상태인 가장 최신의 Cart ID를 가져오기
+     * @param memberId 멤버 ID
+     * @return 장바구니 ID
+     */
+    Long selectActiveCartByMemberId(@Param("memberId") Long memberId);
+
+    /**
+     * Cart ID에 해당하는 장바구니 아이템 가져오기
+     * @param cartId 장바구니 ID
+     * @return 장바구니 아이템 리스트
+     */
+    List<CartItemVO> selectCartItemsByCartId(@Param("cartId") Long cartId);
+
+    /**
+     * 새로운 장바구니 생성
+     * @param cart 장바구니 객체
+     */
+    void insertCart(CartVO cart);
+}

--- a/src/main/java/com/ite/sws/domain/cart/service/CartService.java
+++ b/src/main/java/com/ite/sws/domain/cart/service/CartService.java
@@ -1,0 +1,26 @@
+package com.ite.sws.domain.cart.service;
+
+import com.ite.sws.domain.cart.dto.GetCartRes;
+
+/**
+ * 장바구니 서비스
+ * @author 김민정
+ * @since 2024.08.26
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자       수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.26  	김민정       최초 생성
+ * 2024.08.26  	김민정       MemberId로 장바구니 아이템 조회 기능 추가
+ * </pre>
+ */
+public interface CartService {
+
+    /**
+     * MemberId로 장바구니 아이템 조회
+     * @param memberId 멤버 식별자
+     * @return 장바구니 아이템 리스트
+     */
+    GetCartRes findCartItemListByMemberId(Long memberId);
+}

--- a/src/main/java/com/ite/sws/domain/cart/service/CartServiceImpl.java
+++ b/src/main/java/com/ite/sws/domain/cart/service/CartServiceImpl.java
@@ -1,0 +1,76 @@
+package com.ite.sws.domain.cart.service;
+
+import com.ite.sws.domain.cart.dto.GetCartRes;
+import com.ite.sws.domain.cart.mapper.CartMapper;
+import com.ite.sws.domain.cart.vo.CartItemVO;
+import com.ite.sws.domain.cart.vo.CartVO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 장바구니 서비스 구현체
+ * @author 김민정
+ * @since 2024.08.26
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자       수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.26  	김민정       최초 생성
+ * 2024.08.26  	김민정       MemberId로 장바구니 아이템 조회 기능 추가
+ * 2024.08.26   김민정       새로운 장바구니 생성 기능 추가
+ * </pre>
+ */
+@Service
+@RequiredArgsConstructor
+public class CartServiceImpl implements CartService {
+
+    private final CartMapper cartMapper;
+
+    /**
+     * MemberId로 장바구니 아이템 조회
+     * @param memberId 멤버 식별자
+     * @return 장바구니 아이템 리스트
+     */
+    @Override
+    @Transactional
+    public GetCartRes findCartItemListByMemberId(Long memberId) {
+        // 장바구니에서 ACTIVE인 상태 중 가장 최근에 생성된 cart 가져오기
+        Long cartId = cartMapper.selectActiveCartByMemberId(memberId);
+
+
+        // 해당 유저의 장바구니가 없을 시, 장바구니 생성
+        if (cartId == null) {
+            cartId = createNewCart(memberId);
+        }
+
+        // 해당 cart_id에 속하는 cart items 가져오기
+        List<CartItemVO> cartItems = cartMapper.selectCartItemsByCartId(cartId);
+
+        return GetCartRes.builder()
+                .cartId(cartId)
+                .items(cartItems)
+                .build();
+    }
+
+    /**
+     * 새로운 장바구니 생성
+     * @param memberId 멤버 식별자
+     * @return 새로 생성된 장바구니 ID
+     */
+    private Long createNewCart(Long memberId) {
+        // 장바구니 생성 시 필요한 데이터 설정
+        CartVO newCart = CartVO.builder()
+                .memberId(memberId)
+                .build();
+
+        // 장바구니 생성
+        cartMapper.insertCart(newCart);
+
+        // 새로 생성된 장바구니의 ID 반환
+        return newCart.getCartId();
+    }
+}

--- a/src/main/java/com/ite/sws/domain/cart/vo/CartItemVO.java
+++ b/src/main/java/com/ite/sws/domain/cart/vo/CartItemVO.java
@@ -1,0 +1,30 @@
+package com.ite.sws.domain.cart.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * CartItem VO
+ * @author 김민정
+ * @since 2024.08.26
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자       수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.26  	김민정       최초 생성
+ * </pre>
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class CartItemVO {
+    private Long productId;
+    private int quantity;
+    private String productName;
+    private int productPrice;
+    private String productThumbnail;
+}

--- a/src/main/java/com/ite/sws/domain/cart/vo/CartVO.java
+++ b/src/main/java/com/ite/sws/domain/cart/vo/CartVO.java
@@ -1,0 +1,32 @@
+package com.ite.sws.domain.cart.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * Cart VO
+ * @author 김민정
+ * @since 2024.08.26
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자       수정내용
+ * ----------  --------    ---------------------------
+ * 2024.08.26  	김민정       최초 생성
+ * </pre>
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class CartVO {
+    private Long cartId;
+    private Long memberId;
+    private String status;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/resources/com/ite/sws/domain/cart/mapper/CartMapper.xml
+++ b/src/main/resources/com/ite/sws/domain/cart/mapper/CartMapper.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+ <!-- 
+ * 장바구니 Mybatis 매퍼
+ * @author 김민정
+ * @since 2024.08.26
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일       수정자        수정내용
+ * ==========  =========    =========
+ * 2024.08.26  김민정        최초 생성
+ * 2024.08.26  김민정        ACTIVE 상태인 가장 최신의 Cart ID를 가져오기
+ * 2024.08.26  김민정        Cart ID에 해당하는 장바구니 아이템 가져오기
+ * 2024.08.26  김민정        새로운 장바구니 생성
+ * </pre>
+ -->
+ 
+<mapper namespace="com.ite.sws.domain.cart.mapper.CartMapper">
+	<!-- ACTIVE 상태인 가장 최신의 Cart ID를 가져오기 -->
+	<select id="selectActiveCartByMemberId" resultType="java.lang.Long">
+		SELECT CART_ID
+		FROM CART
+		WHERE MEMBER_ID = #{memberId}
+		  AND STATUS = 'ACTIVE'
+		ORDER BY CREATED_AT DESC
+			FETCH FIRST 1 ROWS ONLY
+	</select>
+
+	<!-- Cart ID에 해당하는 장바구니 아이템 가져오기 -->
+	<select id="selectCartItemsByCartId" resultType="com.ite.sws.domain.cart.vo.CartItemVO">
+		SELECT
+			CI.PRODUCT_ID AS productId,
+			CI.QUANTITY AS quantity,
+			P.NAME AS productName,
+			P.PRICE AS productPrice,
+			P.THUMBNAIL_IMAGE AS productThumbnail
+		FROM CART_ITEM CI
+				 JOIN PRODUCT P ON CI.PRODUCT_ID = P.PRODUCT_ID
+		WHERE CI.CART_ID = #{cartId}
+		  AND CI.IS_DELETED = 0
+	</select>
+
+	<!-- 새로운 장바구니 생성 -->
+	<insert id="insertCart">
+		<selectKey keyProperty="cartId" resultType="long" order="BEFORE">
+			SELECT SEQ_CART_ID.NEXTVAL FROM DUAL
+		</selectKey>
+		INSERT INTO CART (CART_ID, MEMBER_ID)
+		VALUES (#{cartId}, #{memberId})
+	</insert>
+
+</mapper>

--- a/src/main/resources/com/ite/sws/domain/cart/mapper/CartMapper.xml
+++ b/src/main/resources/com/ite/sws/domain/cart/mapper/CartMapper.xml
@@ -21,35 +21,38 @@
 <mapper namespace="com.ite.sws.domain.cart.mapper.CartMapper">
 	<!-- ACTIVE 상태인 가장 최신의 Cart ID를 가져오기 -->
 	<select id="selectActiveCartByMemberId" resultType="java.lang.Long">
-		SELECT CART_ID
-		FROM CART
-		WHERE MEMBER_ID = #{memberId}
-		  AND STATUS = 'ACTIVE'
+		SELECT   CART_ID
+		FROM     CART
+		WHERE    MEMBER_ID = #{memberId}
+		AND      STATUS = 'ACTIVE'
 		ORDER BY CREATED_AT DESC
-			FETCH FIRST 1 ROWS ONLY
+		FETCH FIRST 1 ROWS ONLY
 	</select>
 
 	<!-- Cart ID에 해당하는 장바구니 아이템 가져오기 -->
 	<select id="selectCartItemsByCartId" resultType="com.ite.sws.domain.cart.vo.CartItemVO">
-		SELECT
-			CI.PRODUCT_ID AS productId,
-			CI.QUANTITY AS quantity,
-			P.NAME AS productName,
-			P.PRICE AS productPrice,
-			P.THUMBNAIL_IMAGE AS productThumbnail
-		FROM CART_ITEM CI
-				 JOIN PRODUCT P ON CI.PRODUCT_ID = P.PRODUCT_ID
-		WHERE CI.CART_ID = #{cartId}
-		  AND CI.IS_DELETED = 0
+		SELECT CI.PRODUCT_ID     AS productId,
+			   CI.QUANTITY       AS quantity,
+			   P.NAME            AS productName,
+			   P.PRICE           AS productPrice,
+			   P.THUMBNAIL_IMAGE AS productThumbnail
+		FROM   CART_ITEM CI
+			   JOIN PRODUCT P ON CI.PRODUCT_ID = P.PRODUCT_ID
+		WHERE  CI.CART_ID = #{cartId}
+       	AND CI.IS_DELETED = 0
 	</select>
 
 	<!-- 새로운 장바구니 생성 -->
 	<insert id="insertCart">
 		<selectKey keyProperty="cartId" resultType="long" order="BEFORE">
-			SELECT SEQ_CART_ID.NEXTVAL FROM DUAL
+			SELECT SEQ_CART_ID.NEXTVAL
+			FROM   DUAL
 		</selectKey>
-		INSERT INTO CART (CART_ID, MEMBER_ID)
-		VALUES (#{cartId}, #{memberId})
+		INSERT INTO CART
+					(CART_ID,
+					 MEMBER_ID)
+		VALUES      (#{cartId},
+					 #{memberId})
 	</insert>
 
 </mapper>


### PR DESCRIPTION
## ✨ 작업한 내용
- 장바구니 아이템 조회 API 생성
- 사용자에 장바구니가 존재하지 않을 시, 생성 후 조회

## 🍰 참고 사항
- 회원 구현 전이라서, memberId를 받는 것으로 구현했습니다.

## 📷 스크린샷 또는 GIF
![image](https://github.com/user-attachments/assets/68dd02fe-b10f-4748-99c8-f68293830133)

## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
