### PR TITLE
[SWS-80] 결제 후, 새로운 장바구니 ID 반환 기능 추가

### DIFF
--- a/src/main/java/com/ite/sws/domain/cart/controller/CartController.java
+++ b/src/main/java/com/ite/sws/domain/cart/controller/CartController.java
@@ -32,7 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
  * 2024.08.26  	김민정       최초 생성
  * 2024.08.26  	김민정       장바구니 조회 API 생성
  * 2024.08.26   남진수       장바구니 로그인 API 생성
- * 2024.08.26  	김민정       장바구니 항목 추가 및 수량 증가 API 생성
+ * 2024.08.26  	김민정       장바구니 아이템 추가 API 생성
  * 2024.08.26  	김민정       장바구니 수량 변경 API 생성
  * 2024.08.26  	김민정       장바구니 아이템 삭제 API 생성
  * 2024.08.31  	김민정       PathVariable에서 memberId 제거
@@ -66,7 +66,7 @@ public class CartController {
     }
 
     /**
-     * 장바구니 항목 추가 및 수량 증가 API
+     * 장바구니 아이템 추가 API
      * @param postCartItemReq 장바구니 아이템 객체
      * @return 장바구니 상품 담기 결과 응답
      */

--- a/src/main/java/com/ite/sws/domain/payment/mapper/PaymentMapper.java
+++ b/src/main/java/com/ite/sws/domain/payment/mapper/PaymentMapper.java
@@ -1,5 +1,6 @@
 package com.ite.sws.domain.payment.mapper;
 
+import com.ite.sws.domain.payment.vo.CartQRCodeVO;
 import com.ite.sws.domain.payment.vo.PaymentVO;
 import com.ite.sws.domain.product.vo.ProductVO;
 import org.apache.ibatis.annotations.Param;
@@ -19,6 +20,7 @@ import org.apache.ibatis.annotations.Param;
  * 2024.08.28  	김민정       결제 ID를 통한 출입증 상태 사용 처리
  * 2024.08.30  	김민정       멤버의 이전 구매 기록에서 비슷한 가격대의 제품을 찾기
  * 2024.08.30  	김민정       전체 상품 중에서 비슷한 가격대의 제품을 찾기
+ * 2024.09.01   김민정       결제 후, 새로운 장바구니 ID 반환 기능 추가
  * </pre>
  */
 public interface PaymentMapper {
@@ -31,13 +33,9 @@ public interface PaymentMapper {
 
     /**
      * 새로운 장바구니 및 인증 QR 정보 삽입을 위한 프로시저 호출
-     * @param cartId 기존 장바구니 ID
-     * @param paymentId 결제 ID
-     * @param qrCodeUri QR 코드 URI
+     * @param cartQRCodeVO 장바구니 및 QR 생성 객체
      */
-    void insertCartAndQRCode(@Param("cartId") Long cartId,
-                             @Param("paymentId") Long paymentId,
-                             @Param("qrCodeUri") String qrCodeUri);
+    Long insertCartAndQRCode(CartQRCodeVO cartQRCodeVO);
 
     /**
      * 결제 ID를 통한 출입증 상태 사용 처리

--- a/src/main/java/com/ite/sws/domain/payment/service/PaymentServiceImpl.java
+++ b/src/main/java/com/ite/sws/domain/payment/service/PaymentServiceImpl.java
@@ -8,6 +8,7 @@ import com.ite.sws.domain.payment.dto.GetProductRecommendationRes;
 import com.ite.sws.domain.payment.dto.PostPaymentReq;
 import com.ite.sws.domain.payment.dto.PostPaymentRes;
 import com.ite.sws.domain.payment.mapper.PaymentMapper;
+import com.ite.sws.domain.payment.vo.CartQRCodeVO;
 import com.ite.sws.domain.payment.vo.PaymentVO;
 import com.ite.sws.domain.product.vo.ProductVO;
 import com.ite.sws.exception.CustomException;
@@ -43,6 +44,7 @@ import static com.ite.sws.exception.ErrorCode.EXIT_CREDENTIAL_NOT_FOUND;
  * 2024.08.30  	김민정       주차 시간에 따른 주차 요금 계산
  * 2024.08.28  	김민정       주차 시간에 따른 필요한 최소 구매 금액을 결정
  * 2024.08.28  	김민정       추가 구매가 필요한 금액에 가장 가까운 상품을 조회
+ * 2024.09.01  	김민정       결제 후, 새로운 장바구니 ID 반환 기능 추가
  * </pre>
  */
 @Service
@@ -103,9 +105,16 @@ public class PaymentServiceImpl implements PaymentService {
         // 3-1. 이전 장바구니를 가졌던 유저에게, 새로운 장바구니 생성
         // 3-2. QR 코드 저장, 반환
         // TODO: 장바구니 URI 암호화
-        paymentMapper.insertCartAndQRCode(postPaymentReq.getCartId(), newPayment.getPaymentId(), qrCodeUri);
+        CartQRCodeVO cartQRCodeVO = CartQRCodeVO.builder()
+                .cartId(postPaymentReq.getCartId())
+                .paymentId(newPayment.getPaymentId())
+                .qrCodeUri(qrCodeUri)
+                .build();
+        paymentMapper.insertCartAndQRCode(cartQRCodeVO);
+
         return PostPaymentRes.builder()
                 .paymentId(newPayment.getPaymentId())
+                .newCartId(cartQRCodeVO.getNewCartId())
                 .qrUrl(qrCodeUri)
                 .build();
     }

--- a/src/main/java/com/ite/sws/domain/payment/vo/CartQRCodeVO.java
+++ b/src/main/java/com/ite/sws/domain/payment/vo/CartQRCodeVO.java
@@ -1,4 +1,4 @@
-package com.ite.sws.domain.payment.dto;
+package com.ite.sws.domain.payment.vo;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -6,24 +6,24 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
- * 상품 결제 Response DTO
+ * CartQRCode VO
  * @author 김민정
- * @since 2024.08.30
+ * @since 2024.09.01
  * @version 1.0
  *
  * <pre>
  * 수정일        수정자       수정내용
  * ----------  --------    ---------------------------
- * 2024.08.30  	김민정       최초 생성
- * 2024.09.01  	김민정       새로운 cartId 필드 추가
+ * 2024.09.01  	김민정       최초 생성
  * </pre>
  */
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 @Getter
-public class PostPaymentRes {
+public class CartQRCodeVO {
+    private Long cartId;
     private Long paymentId;
+    private String qrCodeUri;
     private Long newCartId;
-    private String qrUrl;
 }

--- a/src/main/resources/com/ite/sws/domain/payment/mapper/PaymentMapper.xml
+++ b/src/main/resources/com/ite/sws/domain/payment/mapper/PaymentMapper.xml
@@ -16,6 +16,7 @@
 * 2024.08.28  김민정        새로운 장바구니 및 인증 QR 정보 삽입을 위한 프로시저 호출
 * 2024.08.30  김민정        멤버의 이전 구매 기록에서 비슷한 가격대의 제품을 찾기
 * 2024.08.30  김민정        전체 상품 중에서 비슷한 가격대의 제품을 찾기
+* 2024.09.01  김민정        결제 후, 새로운 장바구니 ID 반환 기능 추가
 * </pre>
 -->
 <mapper namespace="com.ite.sws.domain.payment.mapper.PaymentMapper">
@@ -33,11 +34,12 @@
 	</insert>
 
 	<!-- 새로운 장바구니 및 인증 QR 정보 삽입을 위한 프로시저 호출 -->
-	<insert id="insertCartAndQRCode">
+	<insert id="insertCartAndQRCode" parameterType="com.ite.sws.domain.payment.vo.CartQRCodeVO" statementType="CALLABLE">
 		CALL PROC_INSERT_CART_AND_QRCODE(
-			#{cartId},
-			#{paymentId},
-			#{qrCodeUri}
+			#{cartId, mode=IN, jdbcType=NUMERIC},
+			#{paymentId, mode=IN, jdbcType=NUMERIC},
+			#{qrCodeUri, mode=IN, jdbcType=VARCHAR},
+			#{newCartId, mode=OUT, jdbcType=NUMERIC, javaType=java.lang.Long}
 			)
 	</insert>
 


### PR DESCRIPTION
## ✨ 작업한 내용
- 결제 후, 새로운 장바구니 ID 반환 기능 추가

## 🍰 참고 사항
토큰으로 cartId에 접근하던 코드를 롤백했습니다.
결제 후, 새로운 장바구니 id를 클라이언트로 전달하는 기능으로 대신합니다.

## 📷 스크린샷 또는 GIF
![image](https://github.com/user-attachments/assets/f1fb9dad-8515-4bdb-8f3b-ff7717d36c86)

## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
