### PR TITLE
[SWS-122] 주차 정산 반환값 추가

### DIFF
--- a/src/main/java/com/ite/sws/domain/parking/dto/GetParkingRes.java
+++ b/src/main/java/com/ite/sws/domain/parking/dto/GetParkingRes.java
@@ -16,6 +16,7 @@ import java.time.LocalDateTime;
  * 수정일        수정자       수정내용
  * ----------  --------    ---------------------------
  * 2024.08.28  	남진수       최초 생성
+ * 2024.09.07  	남진수       무료 출차 관련 반환값 추가
  * </pre>
  */
 @Getter
@@ -23,6 +24,8 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 public class GetParkingRes {
+    private String freeParkingTime; // 무료 출차 가능 시간
+    private Long feeForFreeParking; // 무료로 출차하기 위한 금액
     private LocalDateTime entranceAt; // 입차 시간
     private String carNumber; // 차량 번호
     private Long discountParkingHour; // 할인 주차 시간(시)

--- a/src/main/java/com/ite/sws/domain/parking/dto/GetParkingRes.java
+++ b/src/main/java/com/ite/sws/domain/parking/dto/GetParkingRes.java
@@ -24,6 +24,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 public class GetParkingRes {
+    private String paymentStatus; // 주차 결제 상태 (null, ACTIVE, CANCEL)
     private String freeParkingTime; // 무료 출차 가능 시간
     private Long feeForFreeParking; // 무료로 출차하기 위한 금액
     private LocalDateTime entranceAt; // 입차 시간

--- a/src/main/java/com/ite/sws/domain/parking/dto/ParkingPaymentDTO.java
+++ b/src/main/java/com/ite/sws/domain/parking/dto/ParkingPaymentDTO.java
@@ -1,0 +1,27 @@
+package com.ite.sws.domain.parking.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 주차 결제 정보 DTO
+ * @author 남진수
+ * @since 2024.09.08
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자       수정내용
+ * ----------  --------    ---------------------------
+ * 2024.09.08  	남진수       최초 생성
+ * </pre>
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ParkingPaymentDTO {
+    private Integer paymentAmount;
+    private Long paymentId;
+}

--- a/src/main/java/com/ite/sws/domain/parking/mapper/ParkingMapper.java
+++ b/src/main/java/com/ite/sws/domain/parking/mapper/ParkingMapper.java
@@ -2,6 +2,7 @@ package com.ite.sws.domain.parking.mapper;
 
 import com.ite.sws.domain.parking.dto.CartItemListDTO;
 import com.ite.sws.domain.parking.dto.ParkingHistoryDTO;
+import com.ite.sws.domain.parking.dto.ParkingPaymentDTO;
 import com.ite.sws.domain.parking.vo.ParkingHistoryVO;
 import java.util.List;
 
@@ -52,11 +53,11 @@ public interface ParkingMapper {
     ParkingHistoryDTO selectParkingHistoryByMemberId(Long memberId);
 
     /**
-     * 결제 금액 조회
+     * 결제 관련 정보 조회
      * @param memberId 회원 ID
-     * @return 무료 주차 시간
+     * @return 결제 ID, 결제 금액
      */
-    Integer selectPaymentAmountByMemberId(Long memberId);
+    ParkingPaymentDTO selectPaymentIdAndAmountByMemberId(Long memberId);
 
     /**
      * 장바구니금액 정보 조회
@@ -65,5 +66,10 @@ public interface ParkingMapper {
      */
     List<CartItemListDTO> selectCartItemListByMemberId(Long memberId);
 
-
+    /**
+     * 주차 결제 상태 조회
+     * @param parkingPaymentId 주차 결제 ID
+     * @return 주차 결제 상태
+     */
+    String selectParkingPaymentStatusByPaymentId(Long parkingPaymentId);
 }

--- a/src/main/java/com/ite/sws/domain/parking/service/ParkingServiceImpl.java
+++ b/src/main/java/com/ite/sws/domain/parking/service/ParkingServiceImpl.java
@@ -79,11 +79,18 @@ public class ParkingServiceImpl implements ParkingService{
         int totalPrice;
         String parkingPaymentStatus;
 
-        // 회원의 결제 금액 조회
-        Integer paymentAmount = parkingMapper.selectPaymentAmountByMemberId(memberId);
+        // 결제 관련 정보 조회
+        ParkingPaymentDTO parkingPaymentDTO = parkingMapper.selectPaymentIdAndAmountByMemberId(memberId);
+
+        // 주차 결제 상태
+        String paymentStatus = null;
+
         // 당일 결제 금액이 존재할 경우
-        if (paymentAmount != null) {
-            totalPrice = paymentAmount;
+        if (parkingPaymentDTO != null) {
+            // 결제 금액
+            totalPrice = parkingPaymentDTO.getPaymentAmount();
+            // 주차 결제 상태 조회
+            paymentStatus = parkingMapper.selectParkingPaymentStatusByPaymentId(parkingPaymentDTO.getPaymentId());
             parkingPaymentStatus = "PAID";
         } else {
             // 회원의 장바구니 목록 조회
@@ -137,6 +144,7 @@ public class ParkingServiceImpl implements ParkingService{
         Long parkingFee = (paidParkingTime.toMinutes() / 10 + (paidParkingTime.toMinutes() % 10 > 0 ? 1L : 0L)) * 1000L;
 
         return GetParkingRes.builder()
+                .paymentStatus(paymentStatus)
                 .freeParkingTime(freeParkingTime)
                 .feeForFreeParking(feeForFreeParking)
                 .entranceAt(parkingHistoryDTO.getEntranceAt())

--- a/src/main/java/com/ite/sws/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/ite/sws/domain/payment/service/PaymentService.java
@@ -17,6 +17,7 @@ import com.ite.sws.domain.payment.dto.PostPaymentRes;
  * 2024.08.28  	김민정       상품 결제 기능 추가
  * 2024.08.28  	김민정       출입증 인증 기능 추가
  * 2024.08.28  	김민정       무료 주차 정산 가능 금액대 상품 조회
+ * 2024.09.08  	김민정       주차 시간에 따른 필요한 최소 구매 금액을 결정
  * </pre>
  */
 public interface PaymentService {
@@ -39,4 +40,11 @@ public interface PaymentService {
      * @return
      */
     GetProductRecommendationRes findRecommendProduct(Long cartId);
+
+    /**
+     * 주차 시간에 따른 필요한 최소 구매 금액을 결정
+     * @param parkedMinutes 주차 시간 (분)
+     * @return 필요한 최소 구매 금액 (원)
+     */
+    int determineRequiredPurchaseAmount(long parkedMinutes);
 }

--- a/src/main/java/com/ite/sws/domain/payment/service/PaymentServiceImpl.java
+++ b/src/main/java/com/ite/sws/domain/payment/service/PaymentServiceImpl.java
@@ -228,7 +228,7 @@ public class PaymentServiceImpl implements PaymentService {
      * @param parkedMinutes 주차 시간 (분)
      * @return 필요한 최소 구매 금액 (원)
      */
-    private int determineRequiredPurchaseAmount(long parkedMinutes) {
+    public int determineRequiredPurchaseAmount(long parkedMinutes) {
         // 무료 주차 시간 기준 (분 단위)
         final int ONE_HOUR = 60;
         final int TWO_HOURS = 120;

--- a/src/main/resources/com/ite/sws/domain/parking/mapper/ParkingMapper.xml
+++ b/src/main/resources/com/ite/sws/domain/parking/mapper/ParkingMapper.xml
@@ -17,6 +17,7 @@
  * 2024.08.28  남진수        주차 기록 조회
  * 2024.08.28  남진수        결제 금액 조회
  * 2024.08.28  남진수        장바구니 금액 조회
+ * 2024.09.08  남진수        주차 결제 상태 조회
  * </pre>
  -->
 
@@ -59,9 +60,10 @@
                AND EXIT_AT IS NULL
     </select>
 
-    <!-- 결제 금액 조회 -->
-    <select id="selectPaymentAmountByMemberId">
-        SELECT   P.AMOUNT
+    <!-- 결제 관련 정보 조회 -->
+    <select id="selectPaymentIdAndAmountByMemberId">
+        SELECT   P.AMOUNT,
+                 P.PAYMENT_ID
         FROM     MEMBER M
                  JOIN CART C
                    ON M.MEMBER_ID = C.MEMBER_ID
@@ -88,6 +90,15 @@
                      ON P.PRODUCT_ID = CI.PRODUCT_ID
         WHERE  M.MEMBER_ID = #{memberId}
         AND C.STATUS = 'ACTIVE'
+    </select>
+
+    <!-- 주차 결제 상태 조회 -->
+    <select id="selectParkingPaymentStatusByPaymentId" >
+        SELECT STATUS
+        FROM   PARKING_PAYMENT
+        WHERE  PAYMENT_ID = #{paymentId}
+        ORDER BY CREATED_AT DESC
+        FETCH FIRST 1 ROWS ONLY
     </select>
 
 </mapper>


### PR DESCRIPTION
## ✨ 작업한 내용
- 주차 정산 시 무료주차 가능 시간 안내를 위한 반환값 추가

## 🍀 PR Point
- 무료 주차가 가능하다면 몇시까지 나갈 수 있는지 시간을 반환
- 주차 정산이 필요하다면 무료주차까지 필요한 금액을 반환
- 최대로 할인을 받아도 무료주차가 불가능하다면 안내문구 반환

## 🍰 참고 사항
@serak0310 findParkingInformation 을 사용하기위해 public으로 바꿨습니다..! 확인부탁 바랍니다~!

## 📷 스크린샷 또는 GIF
- 장바구니에 담긴 금액으로 무료주차가 가능하기에 현재 금액으로 무료 출차 가능한 시간을 반환
<img width="626" alt="image" src="https://github.com/user-attachments/assets/bff4e85d-81c9-417b-a229-27ec13cbe3ca">

## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
