### PR TITLE
[SWS-127] 상품구매 로직변경

### DIFF
--- a/src/main/java/com/ite/sws/domain/cart/mapper/CartMapper.java
+++ b/src/main/java/com/ite/sws/domain/cart/mapper/CartMapper.java
@@ -39,6 +39,7 @@ import java.util.Optional;
  * 2024.09.06   남진수       memberId로 cartMemberId 조회 기능 추가
  * 2024.09.08   김민정       cartMemberId로 장바구니 유저 이름 조회
  * 2024.09.08   김민정       productId로 채팅용 상품 정보 조회
+ * 2024.09.08   김민정       cartId로 memberId 조회
  * </pre>
  */
 public interface CartMapper {
@@ -144,4 +145,11 @@ public interface CartMapper {
      */
     CartItemChatDTO selectCartItemChatDetails(@Param("productId") Long productId,
                                               @Param("cartMemberId") Long cartMemberId);
+
+    /**
+     * cartId로 memberId 조회
+     * @param cartId 장바구니 ID
+     * @return
+     */
+    Long selectMemberIdByCartId(@Param("cartId") Long cartId);
 }

--- a/src/main/java/com/ite/sws/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/ite/sws/domain/payment/controller/PaymentController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -61,10 +62,12 @@ public class PaymentController {
     /**
      * 무료 주차 정산 가능 금액대 상품 추천 API
      * @param cartId 장바구니 ID
+     * @param totalPrice 장바구니 총 금액
      * @return
      */
     @GetMapping("/carts/{cartId}/recommend")
-    public ResponseEntity<GetProductRecommendationRes> findRecommendProduct(@PathVariable Long cartId) {
-        return ResponseEntity.ok(paymentService.findRecommendProduct(cartId));
+    public ResponseEntity<GetProductRecommendationRes> findRecommendProduct(@PathVariable Long cartId,
+                                                                            @RequestParam Long totalPrice) {
+        return ResponseEntity.ok(paymentService.findRecommendProduct(cartId, totalPrice));
     }
 }

--- a/src/main/java/com/ite/sws/domain/payment/dto/PostPaymentReq.java
+++ b/src/main/java/com/ite/sws/domain/payment/dto/PostPaymentReq.java
@@ -1,9 +1,12 @@
 package com.ite.sws.domain.payment.dto;
 
+import com.ite.sws.domain.payment.vo.PaymentItemVO;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 /**
  * 상품 결제 Request DTO
@@ -15,6 +18,7 @@ import lombok.NoArgsConstructor;
  * 수정일        수정자       수정내용
  * ----------  --------    ---------------------------
  * 2024.08.28  	김민정       최초 생성
+ * 2024.09.09   김민정       결제 아이템 리스트 필드 추가
  * </pre>
  */
 @AllArgsConstructor
@@ -27,4 +31,5 @@ public class PostPaymentReq {
     private String card;
     private String paymentKey;
     private String paymentTime;
+    private List<PaymentItemVO> items;
 }

--- a/src/main/java/com/ite/sws/domain/payment/mapper/PaymentMapper.java
+++ b/src/main/java/com/ite/sws/domain/payment/mapper/PaymentMapper.java
@@ -1,9 +1,12 @@
 package com.ite.sws.domain.payment.mapper;
 
 import com.ite.sws.domain.payment.vo.CartQRCodeVO;
+import com.ite.sws.domain.payment.vo.PaymentItemVO;
 import com.ite.sws.domain.payment.vo.PaymentVO;
 import com.ite.sws.domain.product.vo.ProductVO;
 import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
 
 /**
  * 상품 결제 매퍼 인터페이스
@@ -21,6 +24,7 @@ import org.apache.ibatis.annotations.Param;
  * 2024.08.30  	김민정       멤버의 이전 구매 기록에서 비슷한 가격대의 제품을 찾기
  * 2024.08.30  	김민정       전체 상품 중에서 비슷한 가격대의 제품을 찾기
  * 2024.09.01   김민정       결제 후, 새로운 장바구니 ID 반환 기능 추가
+ * 2024.09.10   김민정       결제 아이템 삽입
  * </pre>
  */
 public interface PaymentMapper {
@@ -30,6 +34,13 @@ public interface PaymentMapper {
      * @param newPayment 상품 결제 생성 객체
      */
     void insertPayment(PaymentVO newPayment);
+
+    /**
+     * 결제 아이템 삽입
+     * @param paymentId 생성한 결제 ID
+     * @param items 결제 아이템 목록
+     */
+    void insertPaymentItems(@Param("paymentId") Long paymentId, @Param("items") List<PaymentItemVO> items);
 
     /**
      * 새로운 장바구니 및 인증 QR 정보 삽입을 위한 프로시저 호출

--- a/src/main/java/com/ite/sws/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/ite/sws/domain/payment/service/PaymentService.java
@@ -37,9 +37,10 @@ public interface PaymentService {
     /**
      * 무료 주차 정산 가능 금액대 상품 조회
      * @param cartId 장바구니 ID
+     * @param totalPrice 장바구니 총 금액
      * @return
      */
-    GetProductRecommendationRes findRecommendProduct(Long cartId);
+    GetProductRecommendationRes findRecommendProduct(Long cartId, Long totalPrice);
 
     /**
      * 주차 시간에 따른 필요한 최소 구매 금액을 결정

--- a/src/main/java/com/ite/sws/domain/payment/service/PaymentServiceImpl.java
+++ b/src/main/java/com/ite/sws/domain/payment/service/PaymentServiceImpl.java
@@ -112,6 +112,7 @@ public class PaymentServiceImpl implements PaymentService {
         // 4. 장바구니 및 QR 코드 생성을 위한 프로시저 호출
         // 4-1. 이전 장바구니를 가졌던 유저에게, 새로운 장바구니 생성
         // 4-2. QR 코드 저장, 반환
+        // 4-3. 장바구니 주인의 cart_member_id의 cart_id를 새로운 장바구니로 변경
         CartQRCodeVO cartQRCodeVO = CartQRCodeVO.builder()
             .cartId(postPaymentReq.getCartId())
             .paymentId(newPayment.getPaymentId())

--- a/src/main/java/com/ite/sws/domain/payment/vo/PaymentItemVO.java
+++ b/src/main/java/com/ite/sws/domain/payment/vo/PaymentItemVO.java
@@ -1,0 +1,27 @@
+package com.ite.sws.domain.payment.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 상품 결제 아이템 VO
+ * @author 김민정
+ * @since 2024.09.09
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자       수정내용
+ * ----------  --------    ---------------------------
+ * 2024.09.09  	김민정       최초 생성
+ * </pre>
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class PaymentItemVO {
+    private Long productId;
+    private Integer quantity;
+}

--- a/src/main/java/com/ite/sws/domain/payment/vo/PaymentVO.java
+++ b/src/main/java/com/ite/sws/domain/payment/vo/PaymentVO.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * 상품 결제 VO
@@ -30,4 +31,5 @@ public class PaymentVO {
     private String paymentCard;
     private String paymentKey;
     private LocalDateTime paymentTime;
+    private List<PaymentItemVO> items;
 }

--- a/src/main/resources/com/ite/sws/domain/cart/mapper/CartMapper.xml
+++ b/src/main/resources/com/ite/sws/domain/cart/mapper/CartMapper.xml
@@ -27,6 +27,7 @@
  * 2024.09.06  남진수        memberId로 cartMemberId 조회
  * 2024.09.08  김민정        cartMemberId로 장바구니 유저 이름 조회
  * 2024.09.08  김민정        productId로 채팅용 상품 정보 조회
+ * 2024.09.10  김민정        cartId로 memberId 조회
  * </pre>
  -->
 <mapper namespace="com.ite.sws.domain.cart.mapper.CartMapper">
@@ -212,6 +213,14 @@
 		FROM   PRODUCT P
 		WHERE  P.PRODUCT_ID = #{productId}
 		  AND  P.IS_DELETED = 0
+	</select>
+
+	<!-- cartId로 memberId 조회 -->
+	<select id="selectMemberIdByCartId" resultType="java.lang.Long">
+		SELECT MEMBER_ID
+		FROM   CART
+		WHERE  CART_ID = #{cartId}
+       		   AND STATUS = 'ACTIVE'
 	</select>
 
 </mapper>

--- a/src/main/resources/com/ite/sws/domain/payment/mapper/PaymentMapper.xml
+++ b/src/main/resources/com/ite/sws/domain/payment/mapper/PaymentMapper.xml
@@ -17,6 +17,7 @@
 * 2024.08.30  김민정        멤버의 이전 구매 기록에서 비슷한 가격대의 제품을 찾기
 * 2024.08.30  김민정        전체 상품 중에서 비슷한 가격대의 제품을 찾기
 * 2024.09.01  김민정        결제 후, 새로운 장바구니 ID 반환 기능 추가
+* 2024.09.01  김민정        클라이언트에서 받은 결제 아이템 배열 삽입
 * </pre>
 -->
 <mapper namespace="com.ite.sws.domain.payment.mapper.PaymentMapper">
@@ -31,6 +32,42 @@
 				#{paymentTime, mode=IN, jdbcType=TIMESTAMP},
 				#{paymentId, mode=OUT, jdbcType=NUMERIC}
 			)}
+	</insert>
+
+	<!-- 클라이언트에서 받은 결제 아이템 배열 삽입 -->
+	<insert id="insertPaymentItems" parameterType="map">
+		DECLARE
+		v_name VARCHAR2(100);
+		v_price NUMBER;
+		v_thumbnail_image VARCHAR2(255);
+		BEGIN
+		<foreach collection="items" item="item">
+			-- 각 상품에 대한 정보를 변수에 저장
+			SELECT P.NAME, P.PRICE, P.THUMBNAIL_IMAGE
+			INTO v_name, v_price, v_thumbnail_image
+			FROM PRODUCT P
+			WHERE P.PRODUCT_ID = #{item.productId};
+
+			-- 결제 아이템 삽입
+			INSERT INTO PAYMENT_ITEM (
+			PAYMENT_ITEM_ID,
+			PAYMENT_ID,
+			PRODUCT_ID,
+			NAME,
+			PRICE,
+			QUANTITY,
+			THUMBNAIL_IMAGE
+			) VALUES (
+			SEQ_PAYMENT_ITEM_ID.NEXTVAL,
+			#{paymentId},
+			#{item.productId},
+			v_name,
+			v_price,
+			#{item.quantity},
+			v_thumbnail_image
+			);
+		</foreach>
+		END;
 	</insert>
 
 	<!-- 새로운 장바구니 및 인증 QR 정보 삽입을 위한 프로시저 호출 -->


### PR DESCRIPTION
## ✨ 작업한 내용
- 상품 구매 로직 변경
- 장바구니 주인의 cart_member_id의 cart_id를 새로운 장바구니로 변경

## 🍀 PR Point
결제 중에는 다른 사람이 장바구니 아이템을 변경하면 모르고 결제할 수 있기 때문에,
기존에 장바구니 아이템을 확인해서 select 후 결제 아이템을 그대로 insert하는 로직을 변경했습니다.

결제 아이템 정보를 클라이언트로부터 입력받아 해당 아이템 정보로 결제 아이템 생성됩니다.

## 🍰 참고 사항
장바구니 주인의 cart_member_id의 cart_id를 새로운 장바구니로 변경하는 부분도 Procedure에 변경해두었습니다.

## 📷 스크린샷 또는 GIF
![image](https://github.com/user-attachments/assets/3f24c63e-4d94-490f-9c35-75dca6ecd865)
![image](https://github.com/user-attachments/assets/228e2a4b-cf21-4d1b-aae9-a76476037776)

## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
