### PR TITLE
[SWS-136] 회원/관리자 로그인 로직 분리

### DIFF
--- a/src/main/java/com/ite/sws/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ite/sws/domain/member/controller/MemberController.java
@@ -93,9 +93,13 @@ public class MemberController {
      * @return JwtToken 객체
      */
     @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestHeader(value = "FCM-TOKEN") String fcmToken, @RequestBody PostLoginReq postLoginReq, HttpServletResponse response) {
+    public ResponseEntity<?> login(@RequestHeader(value = "FCM-TOKEN", required = false) String fcmToken,
+                                   @RequestBody PostLoginReq postLoginReq, HttpServletResponse response) {
 
-        postLoginReq.setFcmToken(fcmToken);
+        if (fcmToken != null) {
+            postLoginReq.setFcmToken(fcmToken);
+        }
+
         PostLoginRes postLoginRes = memberService.login(postLoginReq);
         response.addHeader("Authorization", "Bearer " + postLoginRes.getToken());
 

--- a/src/main/java/com/ite/sws/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/com/ite/sws/domain/member/mapper/MemberMapper.java
@@ -30,6 +30,7 @@ import java.util.Optional;
  * 2024.08.27   정은지        장바구니 생성 추가
  * 2024.08.27   정은지        구매 내역 조회 추가
  * 2024.08.27   정은지        작성 리뷰 조회 추가
+ * 2024.09.11   정은지        차량 번호 중복 체크 추가
  * </pre>
  */
 
@@ -41,6 +42,13 @@ public interface MemberMapper {
      * @return 로그인 아이디 개수
      */
     int selectCountByLoginId(String loginId);
+
+    /**
+     * 차량 번호 중복 체크
+     * @param carNumber
+     * @return 등록된 차량 번호 개수
+     */
+    int selectCountByCarNumber(String carNumber);
 
     /**
      * 회원가입

--- a/src/main/java/com/ite/sws/exception/ErrorCode.java
+++ b/src/main/java/com/ite/sws/exception/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
     REVIEW_FILE_TYPE_NOT_PERMITTED(BAD_REQUEST.value(), "올바르지 않은 파일 형식입니다."),
     ALL_FILE_AND_INFO_SHOULD_BE_IN_REQUEST(BAD_REQUEST.value(), "파일과 모든 정보를 입력해야합니다."),
     NO_COMMAND(BAD_REQUEST.value(), "존재하지 않은 명령어입니다."),
+    FCM_TOKEN_MISSING(BAD_REQUEST.value(), "FCM 토큰이 누락되었습니다."),
 
     /* 401: Unauthorized */
     REQUIRED_LOGIN(UNAUTHORIZED.value(), "로그인이 필요합니다."),

--- a/src/main/java/com/ite/sws/exception/ErrorCode.java
+++ b/src/main/java/com/ite/sws/exception/ErrorCode.java
@@ -54,6 +54,7 @@ public enum ErrorCode {
 
     /* 409: Conflict */
     LOGIN_ID_ALREADY_EXISTS(CONFLICT.value(), "이미 존재하는 아이디입니다."),
+    CART_NUMBER_ALREADY_EXISTS(CONFLICT.value(), "이미 등록된 차량입니다."),
 
     /* 500: Internal Server Error */
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부 오류가 발생했습니다."),

--- a/src/main/resources/com/ite/sws/domain/member/mapper/MemberMapper.xml
+++ b/src/main/resources/com/ite/sws/domain/member/mapper/MemberMapper.xml
@@ -20,15 +20,23 @@
 * 2024.08.27    정은지        장바구니 생성 추가
 * 2024.08.27    정은지        구매 내역 아이템 조회 추가
 * 2024.08.27    정은지        작성 리뷰 조회 추가
+* 2024.09.11    정은지        차량 번호 중복 체크 추가
 * </pre>
 -->
 <mapper namespace="com.ite.sws.domain.member.mapper.MemberMapper">
 
-    <!-- 아이디 중복 확인 -->
+    <!-- 아이디 중복 체크 -->
     <select id="selectCountByLoginId" resultType="int">
         SELECT COUNT(*)
         FROM   AUTH
         WHERE  LOGIN_ID = #{loginId}
+    </select>
+
+    <!-- 차량 번호 중복 체크 -->
+    <select id="selectCountByCarNumber" resultType="int">
+        SELECT COUNT(*)
+        FROM   MEMBER
+        WHERE  CAR_NUMBER = #{carNumber}
     </select>
 
     <!-- 회원가입 -->


### PR DESCRIPTION
## ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
- 회원/관리자 로그인 로직 분리
- 회원가입 시 중복된 차량 번호 예외 처리

## 🍀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

## 🍰 참고 사항
관리자 로그인 API를 따로 빼기 보다, 서비스 단에서 로직을 분리하는 게 편할 것 같아 이렇게 했숩니다~~~

## 📷 스크린샷 또는 GIF
- 중복된 차량 번호 예외 처리
![image](https://github.com/user-attachments/assets/3c4adb55-9e4e-474e-9779-a6cef19b4d7e)

## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
