### PR TITLE
[SWS-135] 결제 완료 이벤트(웹소켓 전송) 처리

### DIFF
--- a/src/main/java/com/ite/sws/domain/cart/dto/CartItemMessageDTO.java
+++ b/src/main/java/com/ite/sws/domain/cart/dto/CartItemMessageDTO.java
@@ -16,6 +16,7 @@ import lombok.Setter;
  * 수정일        수정자       수정내용
  * ----------  --------    ---------------------------
  * 2024.09.05  	김민정       최초 생성
+ * 2024.09.11   김민정       메시지 타입 기본값 지정
  * </pre>
  */
 @AllArgsConstructor
@@ -31,4 +32,6 @@ public class CartItemMessageDTO {
     private String productThumbnail;
     @Setter
     private String action; // "create", "increase", "decrease", "delete"
+    @Builder.Default
+    private String type = "cartUpdate";   // "cartUpdate", "paymentDone"
 }

--- a/src/main/java/com/ite/sws/domain/payment/dto/PaymentDoneDTO.java
+++ b/src/main/java/com/ite/sws/domain/payment/dto/PaymentDoneDTO.java
@@ -1,4 +1,4 @@
-package com.ite.sws.domain.payment.vo;
+package com.ite.sws.domain.payment.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -6,25 +6,27 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
- * CartQRCode VO
+ * 결제 완료 DTO
  * @author 김민정
- * @since 2024.09.01
+ * @since 2024.09.11
  * @version 1.0
  *
  * <pre>
  * 수정일        수정자       수정내용
  * ----------  --------    ---------------------------
- * 2024.09.01  	김민정       최초 생성
+ * 2024.09.11  	김민정       최초 생성
  * </pre>
  */
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
 @Getter
-public class CartQRCodeVO {
-    private Long cartId;
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PaymentDoneDTO {
     private Long paymentId;
-    private String qrCodeUri;
+    private Long oldCartId;
     private Long newCartId;
     private String cartOwnerName;
+    private String qrUrl;
+    @Builder.Default
+    private String type = "paymentDone";   // "cartUpdate", "paymentDone"
 }

--- a/src/main/java/com/ite/sws/domain/payment/event/PaymentDoneEvent.java
+++ b/src/main/java/com/ite/sws/domain/payment/event/PaymentDoneEvent.java
@@ -1,0 +1,29 @@
+package com.ite.sws.domain.payment.event;
+
+import com.ite.sws.domain.payment.dto.PaymentDoneDTO;
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+/**
+ * 결제 완료 이벤트 클래스
+ *
+ * @author 김민정
+ * @since 2024.09.11
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자       수정내용
+ * ----------  --------    ---------------------------
+ * 2024.09.11  	김민정       최초 생성
+ * </pre>
+ */
+@Getter
+public class PaymentDoneEvent extends ApplicationEvent {
+
+    private final PaymentDoneDTO paymentDoneDTO;
+
+    public PaymentDoneEvent(Object source, PaymentDoneDTO paymentDoneDTO) {
+        super(source);
+        this.paymentDoneDTO = paymentDoneDTO;
+    }
+}

--- a/src/main/java/com/ite/sws/domain/payment/event/PaymentEventListener.java
+++ b/src/main/java/com/ite/sws/domain/payment/event/PaymentEventListener.java
@@ -1,0 +1,44 @@
+package com.ite.sws.domain.payment.event;
+
+import com.ite.sws.domain.payment.dto.PaymentDoneDTO;
+import com.ite.sws.util.MessageSender;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.MessagingException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+/**
+ * 결제와 관련된 이벤트 리스너 클래스
+ *
+ * @author 김민정
+ * @since 2024.09.11
+ * @version 1.0
+ *
+ * <pre>
+ * 수정일        수정자       수정내용
+ * ----------  --------    ---------------------------
+ * 2024.09.11  	김민정       최초 생성
+ * 2024.09.11   김민정       결제 완료 시, 장바구니 구독자들에게 알림
+ * </pre>
+ */
+@Component
+@RequiredArgsConstructor
+public class PaymentEventListener {
+
+    private final MessageSender messageSender;
+
+    /**
+     * 결제 완료 이벤트 처리
+     * @param event 결제 완료 이벤트 객체
+     */
+    @Async("taskExecutor")
+    @EventListener
+    @Retryable(value = { MessagingException.class }, maxAttempts = 3, backoff = @Backoff(delay = 1000))
+    public void handlePaymentDoneEvent(PaymentDoneEvent event) {
+        PaymentDoneDTO messageDTO = event.getPaymentDoneDTO();
+        messageSender.sendPaymentDone(messageDTO.getOldCartId(), messageDTO);     // 웹소켓으로 메시지 전송
+    }
+}

--- a/src/main/java/com/ite/sws/util/MessageSender.java
+++ b/src/main/java/com/ite/sws/util/MessageSender.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component;
  * 2024.09.06  	김민정       최초 생성
  * 2024.09.06   김민정       장바구니 업데이트 메시지 전송
  * 2024.09.06   김민정       채팅 메시지 전송
+ * 2024.09.11   김민정       결제 정보 전송
  * </pre>
  */
 @Component
@@ -41,6 +42,16 @@ public class MessageSender {
      */
     public void sendChatMessage(Long cartId, Object payload) {
         String destination = "/sub/chat/" + cartId;
+        this.template.convertAndSend(destination, payload);
+    }
+
+    /**
+     * 결제 정보 전송
+     * @param cartId 장바구니 ID
+     * @param payload 결제 관련 정보
+     */
+    public void sendPaymentDone(Long cartId, Object payload) {
+        String destination = "/sub/cart/" + cartId;
         this.template.convertAndSend(destination, payload);
     }
 }

--- a/src/main/resources/com/ite/sws/domain/payment/mapper/PaymentMapper.xml
+++ b/src/main/resources/com/ite/sws/domain/payment/mapper/PaymentMapper.xml
@@ -76,7 +76,8 @@
 			#{cartId, mode=IN, jdbcType=NUMERIC},
 			#{paymentId, mode=IN, jdbcType=NUMERIC},
 			#{qrCodeUri, mode=IN, jdbcType=VARCHAR},
-			#{newCartId, mode=OUT, jdbcType=NUMERIC, javaType=java.lang.Long}
+			#{newCartId, mode=OUT, jdbcType=NUMERIC, javaType=java.lang.Long},
+		    #{cartOwnerName, mode=OUT, jdbcType=VARCHAR, javaType=java.lang.String}
 			)
 	</insert>
 


### PR DESCRIPTION
## ✨ 작업한 내용
- 결제 완료 시, 회원과 비회원에게 웹소켓으로 결제 정보를 알립니다.

## 📷 스크린샷 또는 GIF
- 회원
https://github.com/user-attachments/assets/995598ad-80a2-4c08-a1fa-7f1d5a83ce17

- 비회원
![image](https://github.com/user-attachments/assets/07fcfd19-7231-4d0d-8a3f-368add3b7351)

## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.
